### PR TITLE
WandB Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Dataset
+mvfouls-sub2-lr/
+
+# Wandb
+VARS model/wandb

--- a/VARS model/main.py
+++ b/VARS model/main.py
@@ -10,6 +10,7 @@ import torch.nn as nn
 import torchvision.transforms as transforms
 from model import MVNetwork
 from torchvision.models.video import R3D_18_Weights, R2Plus1D_18_Weights, MViT_V2_S_Weights, Swin3D_T_Weights
+from torchvision.models.video import MC3_18_Weights, S3D_Weights
 import wandb
 
 
@@ -58,9 +59,9 @@ def checkArguments(args):
         exit()
 
     # args.pre_model
-    if args.pre_model not in ["r3d_18", "r2plus1d_18", "mvit_v2_s", "swin3d_t"]:
+    if args.pre_model not in ["r3d_18", "r2plus1d_18", "mvit_v2_s", "swin3d_t", "mc3_18", "s3d"]:
         print("Could not find the desired pretrained model")
-        print("Possible options are: r3d_18, r2plus1d_18, mvit_v2_s, swin3d_t")
+        print("Possible options are: r3d_18, r2plus1d_18, mvit_v2_s, swin3d_t, mc3_18, s3d")
         exit()
 
     # args.only_evaluation
@@ -126,6 +127,10 @@ def main(args, wandb_run, model_artifact):
         transforms_model = MViT_V2_S_Weights.KINETICS400_V1.transforms()
     elif pre_model == "swin3d_t":
         transforms_model = Swin3D_T_Weights.KINETICS400_V1.transforms()
+    elif pre_model == "mc3_18":
+        transforms_model = MC3_18_Weights.KINETICS400_V1.transforms()
+    elif pre_model == "s3d":
+         transforms_model = S3D_Weights.KINETICS400_V1.transforms()
     
 
     # Create only the relevant Datasets and DataLoaders for this task

--- a/VARS model/model.py
+++ b/VARS model/model.py
@@ -6,6 +6,8 @@ from torchvision.models.video import r3d_18, R3D_18_Weights
 from torchvision.models.video import r2plus1d_18, R2Plus1D_18_Weights
 from torchvision.models.video import mvit_v2_s, MViT_V2_S_Weights
 from torchvision.models.video import swin3d_t, Swin3D_T_Weights
+from torchvision.models.video import mc3_18, MC3_18_Weights
+from torchvision.models.video import s3d, S3D_Weights
 
 
 
@@ -32,6 +34,13 @@ class MVNetwork(torch.nn.Module):
         elif net_name == "swin3d_t":                        # Swin3d Transformer (tiny)
             weights_model = Swin3D_T_Weights.DEFAULT        # KINETICS400_V1
             network = swin3d_t(weights=weights_model)
+        elif net_name == "mc3_18":
+            weights_model = MC3_18_Weights.DEFAULT
+            network = mc3_18(weights=weights_model)
+        elif net_name == "s3d":
+            weights_model = S3D_Weights.DEFAULT
+            network = s3d(weights=weights_model)
+            self.feat_dim = 400
         
                 
         network.fc = torch.nn.Sequential()

--- a/VARS model/train.py
+++ b/VARS model/train.py
@@ -102,7 +102,7 @@ def trainer(train_loader,
         scheduler.step()
 
         # Save the model every 4 epochs
-        if (epoch % 1 == 0):
+        if (epoch % 4 == 0):
             state = {
             'epoch': epoch,
             'state_dict': model.state_dict(),

--- a/VARS model/train.py
+++ b/VARS model/train.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import torch
 import gc
@@ -9,14 +8,23 @@ from tqdm import tqdm
 import wandb
 
 def print_results(results, dataset, wandb_run, epoch):
+    
     print("RESULTS: ")
     print("  Action class accuracy: {:.3f} %".format(results["accuracy_action"]))
     print("  Offence severity accuracy:  {:.3f} %".format(results["accuracy_offence_severity"]))
 
-    wandb_run.log({"Epoch": epoch, 
-                   f"{dataset}_acc_action": round(results["accuracy_action"], 3), 
-                   f"{dataset}_acc_offense_severity": round(results["accuracy_offence_severity"], 3)}
-                   )
+    # Log the statistics to Wandb 
+    # Test set -> Summary statistic
+    if (dataset == "Test"):
+        wandb_run.summary["Test_acc_action"] = round(results["accuracy_action"], 3)
+        wandb_run.summary["Test_acc_offense_severity"] = round(results["accuracy_offence_severity"], 3)
+
+    # Train & Validation sets -> Plots    
+    else:
+        wandb_run.log({"Epoch": epoch, 
+                    f"{dataset}_acc_action": round(results["accuracy_action"], 3), 
+                    f"{dataset}_acc_offense_severity": round(results["accuracy_offence_severity"], 3)}
+                    )
 
     return
 
@@ -26,16 +34,10 @@ def set_wandb_metrics(wandb_run):
     wandb_run.define_metric(name="Epoch", hidden=True) # Don't plot the Epoch metric
 
     wandb_run.define_metric(name="Train_acc_action", summary="max", step_metric="Epoch")
-    
     wandb_run.define_metric(name="Valid_acc_action", summary="max", step_metric="Epoch")
 
-    wandb_run.define_metric(name="Test_acc_action", summary="max", step_metric="Epoch")
-
     wandb_run.define_metric(name="Train_acc_offense_severity", summary="max", step_metric="Epoch")
-    
     wandb_run.define_metric(name="Valid_acc_offense_severity", summary="max", step_metric="Epoch")
-    
-    wandb_run.define_metric(name="Test_acc_offense_severity", summary="max", step_metric="Epoch")
 
 
 def trainer(train_loader,
@@ -45,7 +47,7 @@ def trainer(train_loader,
             optimizer,
             scheduler,
             criterion,
-            best_model_path,
+            model_saving_dir,
             epoch_start,
             model_name,
             path_dataset,
@@ -54,8 +56,6 @@ def trainer(train_loader,
             ):
     
 
-    logging.info("start training")
-    counter = 0
     set_wandb_metrics(wandb_run)
 
     for epoch in range(epoch_start, max_epochs+1): # [epoch_start, max_epoch]
@@ -77,8 +77,8 @@ def trainer(train_loader,
         )
         pbar.close()
 
-        results = evaluate(os.path.join(path_dataset, "Train", "annotations.json"), prediction_file)
-        print_results(results, "Train", wandb_run, epoch)
+        results_train = evaluate(os.path.join(path_dataset, "Train", "annotations.json"), prediction_file)
+        print_results(results_train, "Train", wandb_run, epoch)
 
         print("###################### VALIDATION ###################")
         pbar = tqdm(total=len(val_loader2), desc="Validation", position=0, leave=True)
@@ -95,47 +95,60 @@ def trainer(train_loader,
         )
         pbar.close()
 
-        results = evaluate(os.path.join(path_dataset, "Valid", "annotations.json"), prediction_file)
-        print_results(results, "Valid", wandb_run, epoch)
-
-
-        print("###################### TEST ###################")
-        pbar = tqdm(total=len(test_loader2), desc="Test", position=0, leave=True)
-        prediction_file, loss_action, loss_offence_severity = train(
-                test_loader2,
-                model,
-                criterion,
-                optimizer,
-                epoch + 1,
-                model_name,
-                train=False,
-                set_name="test",
-                pbar=pbar
-            )
-        pbar.close()
-
-        results = evaluate(os.path.join(path_dataset, "Test", "annotations.json"), prediction_file)
-        print_results(results, "Test", wandb_run, epoch)
-        
+        results_val = evaluate(os.path.join(path_dataset, "Valid", "annotations.json"), prediction_file)
+        print_results(results_val, "Valid", wandb_run, epoch)
 
         scheduler.step()
 
-        counter += 1
-
-        if counter > 3:
+        # Save the model every 4 epochs
+        if (epoch % 4 == 0):
             state = {
-            'epoch': epoch + 1,
+            'epoch': epoch,
             'state_dict': model.state_dict(),
             'optimizer': optimizer.state_dict(),
             'scheduler': scheduler.state_dict()
             }
             print("***** SAVING MODEL *****")
-            path_aux = os.path.join(best_model_path, str(epoch+1) + "_model.pth.tar")
+            path_aux = os.path.join(model_saving_dir, str(epoch) + "_model.pth.tar")
             torch.save(state, path_aux)
+
+
+    # Evaluate on the Test set after training
+    print("###################### TEST ###################")
+    pbar = tqdm(total=len(test_loader2), desc="Test", position=0, leave=True)
+    prediction_file, loss_action, loss_offence_severity = train(
+            test_loader2,
+            model,
+            criterion,
+            optimizer,
+            epoch + 1,
+            model_name,
+            train=False,
+            set_name="test",
+            pbar=pbar
+        )
+    pbar.close()
+
+    results = evaluate(os.path.join(path_dataset, "Test", "annotations.json"), prediction_file)
+    print_results(results, "Test", wandb_run, epoch)
+    
+
+    # Save the final model if not already done
+    if (max_epochs % 4 != 0):
+        state = {
+            'epoch': epoch,
+            'state_dict': model.state_dict(),
+            'optimizer': optimizer.state_dict(),
+            'scheduler': scheduler.state_dict()
+        }
+        print("***** SAVING MODEL *****")
+        path_aux = os.path.join(model_saving_dir, str(max_epochs) + "_model.pth.tar")
+        torch.save(state, path_aux)
 
     print("###################### TRAINER DONE ###################")
 
     return
+
 
 def train(dataloader,
           model,

--- a/VARS model/train.py
+++ b/VARS model/train.py
@@ -52,6 +52,7 @@ def trainer(train_loader,
             model_name,
             path_dataset,
             wandb_run,
+            model_artifact,
             max_epochs=1000
             ):
     
@@ -101,7 +102,7 @@ def trainer(train_loader,
         scheduler.step()
 
         # Save the model every 4 epochs
-        if (epoch % 4 == 0):
+        if (epoch % 1 == 0):
             state = {
             'epoch': epoch,
             'state_dict': model.state_dict(),
@@ -110,7 +111,9 @@ def trainer(train_loader,
             }
             print("***** SAVING MODEL *****")
             path_aux = os.path.join(model_saving_dir, str(epoch) + "_model.pth.tar")
-            torch.save(state, path_aux)
+            torch.save(state, path_aux) # This saves the state_dict info locally
+            if (model_artifact != None):
+                model_artifact.add_file(path_aux)
 
 
     # Evaluate on the Test set after training
@@ -143,8 +146,12 @@ def trainer(train_loader,
         }
         print("***** SAVING MODEL *****")
         path_aux = os.path.join(model_saving_dir, str(max_epochs) + "_model.pth.tar")
-        torch.save(state, path_aux)
+        torch.save(state, path_aux) # This saves the state_dict info locally
+        if (model_artifact != None):
+            model_artifact.add_file(path_aux)
 
+    if (model_artifact != None):
+        wandb_run.log_artifact(model_artifact)
     print("###################### TRAINER DONE ###################")
 
     return

--- a/requirements-sm.txt
+++ b/requirements-sm.txt
@@ -23,4 +23,5 @@ pydub
 audiofile
 opencv-python
 scikit_learn
+wandb
 git+https://github.com/ajhamdi/mvtorch


### PR DESCRIPTION
Weights and Biases (Wandb) Pipeline

Added two script arguments to main.py:
--wandb_run_name: specific name for the run (required)
--wandb_saving_model_name: artifact name to save the checkpoints (optional)

Each run monitors the Training & Validation accuracies on both tasks through 4 different plots that are updated after each epoch

The Overview sections contains
- The key hyperparameters under Config
- The key results on the Train/Valid/Test under Summary
- (Optionally) The artifact which has the checkpoints for the trained model (checkpoints are saved every 4 epochs and at the end under Files)

The Logs section contains
- The content printed to stdout
- The local logfile wasn't saving anything, everything is now printed to stdout
- I also changed the Total Execution Time format to HH:MM:SS

Additional Functional Changes
- I moved the test set evaluation outside the training loop in train.py, to avoid unnecessarily monitoring the testing loss
- Simplified a lot the local model saving, assuming it would be saved on Wandb as well

TODO
- The code works assuming only_evaluation is set to 3. I didn't try with the other options. 

Observations:
- Calling the "evaluate" function from SoccerNet.Evaluation.MV_FoulRecognition for the first time on the Validation and Test sets (in train.py) generated a RuntimeWarning: invalid value encountered in divide, I don't know if we can change this. Maybe this is why the test set evaluation was also under the training loop
- The "evaluate" function also prints <class 'numpy.ndarray'> to stdout, I don't know if we can change this. Maybe they tried to debug their code (first point above)